### PR TITLE
Fixed the zero filter and finalizeLocalRomSegmentEvaluation index

### DIFF
--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -343,11 +343,11 @@ class ARMA(supervisedLearning):
         self._trainingCDF[target] = mathUtils.trainEmpiricalFunction(timeSeriesData, minBins=self._minBins)
       # if this target governs the zero filter, extract it now
 
-      zeroFiltering = target == self.zeroFilterTarget
-      if not zeroFiltering:
-        if target == self.zeroFilterTarget:
-          self.zeroFilterMask = self._trainZeroRemoval(timeSeriesData,tol=self.zeroFilterTol) # where zeros or less than zeros are
-          self.notZeroFilterMask = np.logical_not(self.zeroFilterMask) # where data are
+      # zeroFiltering = target == self.zeroFilterTarget
+      # if not zeroFiltering:
+      if target == self.zeroFilterTarget:
+        self.zeroFilterMask = self._trainZeroRemoval(timeSeriesData,tol=self.zeroFilterTol) # where zeros or less than zeros are
+        self.notZeroFilterMask = np.logical_not(self.zeroFilterMask) # where data are
       # if we're removing Fourier signal, do that now.
 
       maskPeakRes = np.ones(len(timeSeriesData), dtype=bool)
@@ -386,7 +386,11 @@ class ARMA(supervisedLearning):
         # print('jhl',self.pivotParameterValues)
         # print('jjj',self.fourierParams[target])
         # print('ccc',timeSeriesData)
-
+        # # print(target)
+        # print('lalalala')
+        # # print(self.zeroFilterTarget)
+        # print(self.zeroFilterMask)
+        # print(self.notZeroFilterMask)
         self.fourierResults[target] = self._trainFourier(self.pivotParameterValues,
                                                          self.fourierParams[target],
                                                          timeSeriesData,
@@ -970,16 +974,21 @@ class ARMA(supervisedLearning):
 
     # if using zero-filter, cut the parts of the Fourier and values that correspond to the zero-value portions
     if zeroFilter:
+      print('yeszf')
       # values = values[self.notZeroFilterMask]
       # fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
+      # print('JZ is a debugger ', self.notZeroFilterMask)
+
       values = values[self.notZeroFilterMask]
       fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
+      # values = values[0]
+      # fourierSignals = fourierSignals[0]
     else:
       fourierSignals = fourierSignalsFull
 
     # fit the signal
-    # print('JZ is a debugger ', values)
-    # print('JZ is a debugger fourierSignals', self.zeroFilterMask)
+    # print('JZ is a debugger ', self.notZeroFilterMask)
+    # print('JZ is a debugger fourierSignals', fourierSignals)
 
     fourierEngine.fit(fourierSignals, values)
 
@@ -1062,11 +1071,16 @@ class ARMA(supervisedLearning):
     q = smoother['state_cov',:,:,0]
     selCov = r.dot(q).dot(r.T)
     cov = solve_discrete_lyapunov(smoother['transition',:,:,0], selCov)
-    # print('Here is the cov: \n',cov)
+    print('Here is the smoother: \n',smoother)
+    print('Here is the mean: \n',mean)
+    print('Here is the r: \n',r)
+    print('Here is the q: \n',q)
+    print('Here is the selCov: \n',selCov)
+    print('Here is the cov: \n',cov)
     # FIXME it appears this is always resulting in a lowest-value initial state.  Why?
     initDist = self._trainMultivariateNormal(len(mean),mean,cov)
     # NOTE: uncomment this line to get a printed summary of a lot of information about the fitting.
-    # self.raiseADebug('VARMA model training summary:\n',results.summary())
+    self.raiseADebug('VARMA model training summary:\n',results.summary())
     return model, stateDist, initDist
 
   def _trainZeroRemoval(self, data, tol=1e-10):

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -353,44 +353,12 @@ class ARMA(supervisedLearning):
       maskPeakRes = np.ones(len(timeSeriesData), dtype=bool)
       # Make a full mask
       if target in self.peaks:
-        # print(self.peaks)
-        # deltaT=self.pivotParameterValues[-1]-self.pivotParameterValues[0]
-        # deltaT=deltaT/(len(self.pivotParameterValues)-1)
-        # print(deltaT)
-        # # change the peak information in self.peak from time unit into index by divided the timestep
-        # # deltaT is the time step calculated by (ending point - stating point in time)/(len(time)-1)
-        # self.peaks[target]['period']=int(self.peaks[target]['period']/deltaT)
-        # for i in range(len(self.peaks[target]['windows'])):
-        #   self.peaks[target]['windows'][i]['window'][0]=int(self.peaks[target]['windows'][i]['window'][0]/deltaT)
-        #   self.peaks[target]['windows'][i]['window'][1]=int(self.peaks[target]['windows'][i]['window'][1]/deltaT)
-        #   self.peaks[target]['windows'][i]['width']=int(self.peaks[target]['windows'][i]['width']/deltaT)
-        # groupWin , maskPeakRes=self._peakGroupWindow(timeSeriesData, windowDict=self.peaks[target] )
-        # self.peaks[target]['groupWin']=groupWin
-        # self.peaks[target]['mask']=maskPeakRes
-
-        # rangeWindow = self.rangeWindow(windowDict=self.peaks[target])
-        # self.peaks[target]['rangeWindow']=rangeWindow
-        # print('beforre train')
-        # pp.pprint(self.peaks)
         peakResults=self._trainPeak(timeSeriesData,windowDict=self.peaks[target])
         self.peaks[target].update(peakResults)
         maskPeakRes = peakResults['mask']
-        # pp.pprint(self.peaks)
 
-
-
-        # print(peakResults)
       if target in self.fourierParams:
         self.raiseADebug('... analyzing Fourier signal  for target "{}" ...'.format(target))
-        # print('JZ is a debugger')
-        # print('jhl',self.pivotParameterValues)
-        # print('jjj',self.fourierParams[target])
-        # print('ccc',timeSeriesData)
-        # # print(target)
-        # print('lalalala')
-        # # print(self.zeroFilterTarget)
-        # print(self.zeroFilterMask)
-        # print(self.notZeroFilterMask)
         self.fourierResults[target] = self._trainFourier(self.pivotParameterValues,
                                                          self.fourierParams[target],
                                                          timeSeriesData,
@@ -466,7 +434,6 @@ class ARMA(supervisedLearning):
         self.varmaNoise = (unzNoise, zNoise)
         self.varmaInit = (unzInit, zInit)
       else:
-        # print('jz is a debugger correlation',correlationData)
         varma, noiseDist, initDist = self._trainVARMA(correlationData)
         # FUTURE if extending to multiple VARMA per training, these will need to be dictionaries
         self.varmaResult = (varma,)
@@ -511,7 +478,6 @@ class ARMA(supervisedLearning):
       scale = (1.0 + growth) ** year
     else:
       scale = 1.0 + year * growth
-    # print('jialock holmes is growing',scale)
     return scale
 
   def _evaluateYear(self, featureVals):
@@ -620,7 +586,6 @@ class ARMA(supervisedLearning):
         #returnEvaluation[target+'_2fourier'] = copy.copy(signal)
         debuggFile.writelines('signal_fourier,'+','.join(str(x) for x in self.fourierResults[target]['predict'])+'\n')
       if target in self.peaks:
-        # pp.pprint(self.peaks[target])
         signal = self._transformBackPeaks(signal,windowDict=self.peaks[target])
         debuggFile.writelines('signal_peak,'+','.join(str(x) for x in signal)+'\n')
 
@@ -872,9 +837,7 @@ class ARMA(supervisedLearning):
       data=data[fullMask]
     elif len(masks)==1:
       fullMask =masks[0]
-      # print('jz is full mask', fullMask)
       data = data[fullMask]
-      # print('data',data)
     results = smARMA(data, order = (self.P, self.Q)).fit(disp = False)
     return results
 
@@ -887,7 +850,6 @@ class ARMA(supervisedLearning):
     # caluclate number of bins
     # binOps=Length or value
     nBins = self._computeNumberOfBins(data,binOps=binOps)
-    # print('jz is a debugger inside _trainCDF nbins',nBins)
     # construct histogram
     counts, edges = np.histogram(data, bins = nBins, density = False)
     counts = np.array(counts) / float(len(data))
@@ -923,7 +885,6 @@ class ARMA(supervisedLearning):
     # deltaT is the time step calculated by (ending point - stating point in time)/(len(time)-1)
     peakResults['period']=int(round(windowDict['period']/deltaT))
     windows=[]
-    # pp.pprint(windowDict['windows'])
     for i in range(len(windowDict['windows'])):
       window={}
       a = windowDict['windows'][i]['window'][0]
@@ -939,9 +900,6 @@ class ARMA(supervisedLearning):
     peakResults['nbin']=windowDict['nbin']
     rangeWindow = self.rangeWindow(windowDict=peakResults)
     peakResults['rangeWindow']=rangeWindow
-    # print('gW',groupWin)
-    # print('rW',rangeWindow)
-    # print('jz after train peak results')
     return peakResults
 
   def _trainFourier(self, pivotValues, periods, values, masks=None,zeroFilter=False):
@@ -974,10 +932,8 @@ class ARMA(supervisedLearning):
 
     # if using zero-filter, cut the parts of the Fourier and values that correspond to the zero-value portions
     if zeroFilter:
-      print('yeszf')
       # values = values[self.notZeroFilterMask]
       # fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
-      # print('JZ is a debugger ', self.notZeroFilterMask)
 
       values = values[self.notZeroFilterMask]
       fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
@@ -987,8 +943,6 @@ class ARMA(supervisedLearning):
       fourierSignals = fourierSignalsFull
 
     # fit the signal
-    # print('JZ is a debugger ', self.notZeroFilterMask)
-    # print('JZ is a debugger fourierSignals', fourierSignals)
 
     fourierEngine.fit(fourierSignals, values)
 
@@ -1050,7 +1004,6 @@ class ARMA(supervisedLearning):
       @ Out, initDist, Distributions.MultivariateNormal, MVN from which VARMA initial state is taken
     """
     model = sm.tsa.VARMAX(endog=data, order=(self.P, self.Q))
-    # print(data)
     self.raiseADebug('... ... ... fitting VARMA ...')
     results = model.fit(disp=False,maxiter=1000)
     lenHist,numVars = data.shape
@@ -1071,16 +1024,10 @@ class ARMA(supervisedLearning):
     q = smoother['state_cov',:,:,0]
     selCov = r.dot(q).dot(r.T)
     cov = solve_discrete_lyapunov(smoother['transition',:,:,0], selCov)
-    print('Here is the smoother: \n',smoother)
-    print('Here is the mean: \n',mean)
-    print('Here is the r: \n',r)
-    print('Here is the q: \n',q)
-    print('Here is the selCov: \n',selCov)
-    print('Here is the cov: \n',cov)
     # FIXME it appears this is always resulting in a lowest-value initial state.  Why?
     initDist = self._trainMultivariateNormal(len(mean),mean,cov)
     # NOTE: uncomment this line to get a printed summary of a lot of information about the fitting.
-    self.raiseADebug('VARMA model training summary:\n',results.summary())
+    # self.raiseADebug('VARMA model training summary:\n',results.summary())
     return model, stateDist, initDist
 
   def _trainZeroRemoval(self, data, tol=1e-10):
@@ -1268,8 +1215,6 @@ class ARMA(supervisedLearning):
     for picker in pickers:
       res = dict((target, signal['predict'][picker].mean()) for target, signal in settings['long Fourier signal'].items())
       results.append(res)
-    # print('jz is in _getMeanFromGlobal here here')
-    # print(results)
     return results
 
   def getLocalRomClusterFeatures(self, featureTemplate, settings, request, picker=None, **kwargs):
@@ -1284,7 +1229,6 @@ class ARMA(supervisedLearning):
       @ Out, features, dict, {target_metric: np.array(floats)} features to cluster on
     """
     # algorithm for providing Fourier series and ARMA white noise variance and #TODO covariance
-    # print('jz is inside arma getLocalRomClusterFeatures request', request)
     features = self.getFundamentalFeatures(request, featureTemplate=featureTemplate)
     # segment means
     # since we've already detrended globally, get the means from that (if present)
@@ -1343,23 +1287,17 @@ class ARMA(supervisedLearning):
         feature = featureTemplate.format(target=target, metric='arma', id='MA_{}'.format(q))
         features[feature] = val
       for target, cdfParam in self.cdfParams.items():
-        # print('jz is adebugger inside thecdfpara',target,cdfParam['bins'])
-        # print('jz is adebugger inside thecdfpara',target,cdfParam['counts'])
         lenthOfData = cdfParam['lens']
         feature = featureTemplate.format(target=target, metric='arma', id='len')
         features[feature] = lenthOfData
 
         for e, edge in enumerate(cdfParam['bins']):
-          # print('jz is a debugger inside the cdfpara',e,edge)
           feature = featureTemplate.format(target=target, metric='arma', id='bin_{}'.format(e))
           features[feature] = edge
-        # print('jz is adebugger inside thecdfpara',target,cdfParam[1])
         for c, count in enumerate(cdfParam['counts']):
-          # print('jz is a debugger inside the cdfpara',c,count)
           feature = featureTemplate.format(target=target, metric='arma', id='counts_{}'.format(c))
           features[feature] = count
         # for paraId,paraVal in cdfParam.items():
-        #   print('jz is a debugger in gff cdfpara',paraId,paraVal)
     # CDF preservation if available
     for target, cdf in self._trainingCDF.items():
       _, (counts, edges) = cdf
@@ -1371,8 +1309,6 @@ class ARMA(supervisedLearning):
         features[feature] = edge
 
     for target, peak in self.peaks.items():
-      # print('啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦 我是分界线1 啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦啦')
-      # pp.pprint(self.peaks)
       nBin = self.peaks[target]['nbin']
       period = self.peaks[target]['period']
       if 'groupWin' in peak.keys() and 'rangeWindow' in peak.keys():
@@ -1413,7 +1349,6 @@ class ARMA(supervisedLearning):
           #mean
           if len(group['Amp']):
             if np.isnan((group['Amp'][0])):
-              print('nanan')
               meanAmp = np.mean(self._signalStorage[target]['original'])
             else:
               # meanAmp=rv_histogram(np.histogram(group['Amp'])).mean()
@@ -1423,8 +1358,6 @@ class ARMA(supervisedLearning):
             features[feature] = meanAmp
 
           else:
-            # print(g)
-            # print('  No group found')
             meanAmp = np.mean(self._signalStorage[target]['original'])
             feature = featureTemplate.format(target=target, metric='peak', id='gp_{}_meanAmp'.format(g))
             features[feature] = meanAmp
@@ -1449,9 +1382,6 @@ class ARMA(supervisedLearning):
               features[feature] = minAmp
             else:
               maxAmp=max(group['Amp'])
-              # print('jz is here here')
-              # print(group['Amp'])
-
               feature = featureTemplate.format(target=target, metric='peak', id='gp_{}_maxAmp'.format(g))
               features[feature] = maxAmp
               minAmp=min(group['Amp'])
@@ -1467,8 +1397,6 @@ class ARMA(supervisedLearning):
               feature = featureTemplate.format(target=target, metric='peak', id='gp_{}_amp {}'.format(g,c))
               features[feature] = count
           else:
-            # print('jz is whwhwh')
-            # print(self._signalStorage[target]['original'])
             maxAmp=max(self._signalStorage[target]['original'])
             feature = featureTemplate.format(target=target, metric='peak', id='gp_{}_maxAmp'.format(g))
             features[feature] = maxAmp
@@ -1484,7 +1412,6 @@ class ARMA(supervisedLearning):
     # for target, peak in self.items():
 
     if requestedFeatures is not None:
-      # print(requestedFeatures)
       popFeatures=[]
       for rq in features.keys():
         tg, mtc, rid =rq.split('|')
@@ -1509,12 +1436,9 @@ class ARMA(supervisedLearning):
           elif rid.startswith('l'):
             popFeatures.append(rq)
 
-      # print(popFeatures)
-        # elif mtc=='arma':
+
       for p in popFeatures:
         del features[p]
-    # pp.pprint(features)
-    # cccccccccc
     return features
 
   def readFundamentalFeatures(self, features):
@@ -1555,13 +1479,11 @@ class ARMA(supervisedLearning):
           p = int(ID[4:])
           if 'bin' not in arma[target]:
             arma[target]['bin'] = {}
-          # print('jz is setting the whiten part',val)
           arma[target]['bin'][p] = val
         elif ID.startswith('counts_'):
           p = int(ID[7:])
           if 'counts' not in arma[target]:
             arma[target]['counts'] = {}
-          # print('jz is setting the whiten part two',val)
           arma[target]['counts'][p] = val
 
       elif metric == 'cdf':
@@ -1595,10 +1517,7 @@ class ARMA(supervisedLearning):
 
       else:
         raise KeyError('Unrecognized metric: "{}"'.format(metric))
-      # print('debuggggggg')
-      # pp.pprint(features)
-      # print('debuggggggggg')
-      # pp.pprint(peak)
+
     return {'fourier': fourier,
             'arma': arma,
             'cdf': cdf,
@@ -1641,8 +1560,6 @@ class ARMA(supervisedLearning):
                                      'predict': predict}
 
   def _setArmaResults(self, paramDict):
-    # print('jz is very happy')
-    # pp.pprint(paramDict)
     for target, info in paramDict.items():
       if 'AR' in info:
         AR_keys, AR_vals = zip(*list(info['AR'].items()))
@@ -1667,10 +1584,7 @@ class ARMA(supervisedLearning):
         counts_keys, counts_vals = zip(*list(info['counts'].items()))
         counts_keys, counts_vals = zip(*sorted(zip(counts_keys, counts_vals), key=lambda x:x[0]))
         counts_vals = np.asarray(counts_vals)
-        # print(counts_vals)
       # FIXME no else
-      # else:
-      #   counts_vals = np.array([])
 
       sigma = info['std']
       result = armaResultsProxy(AR_vals, MA_vals, sigma)
@@ -1703,7 +1617,6 @@ class ARMA(supervisedLearning):
       self._trainingCDF[target] = (dist, histogram)
 
   def _setPeakResults(self, paramDict):
-    # print('jz is a peakpicker')
     for target, info in paramDict.items():
       groupWin=[]
       for g, groupInfo in info.items():
@@ -1720,7 +1633,6 @@ class ARMA(supervisedLearning):
 
         if maxAmp>minAmp:
           ampHisEg=np.linspace(minAmp, maxAmp, num=len(ampHisCs)+1)
-        # print('dshflshfahlfhalhflasfhi',ampHisCs)
           histogram = (ampHisCs, ampHisEg)
           dist = stats.rv_histogram(histogram)
           ampLocal=dist.rvs(size=int(round(probExist*lenWin))).tolist()
@@ -1741,10 +1653,7 @@ class ARMA(supervisedLearning):
         for indexOfIndex,valueOfIndex in enumerate(indLocal):
           valueOfIndex=int(valueOfIndex)
           indLocal[indexOfIndex]=valueOfIndex
-        # print('we are inside arma set peak results his',g,histogram)
-        # print('pb',int(probExist*lenWin))
-        # print('we are inside arma set peak results ind',g,indLocal)
-        # print('we are inside arma set peak results amp',g,ampLocal)
+
         groupWin[g]['Ind']=indLocal
         groupWin[g]['Amp']=ampLocal
       self.peaks[target]['groupWin']=groupWin
@@ -1764,13 +1673,10 @@ class ARMA(supervisedLearning):
 
     # set up for input CDF preservation on a global scale
     if self.preserveInputCDF:
-      # print('jz is sth preserve cdf')
-      # print(targets)
       inputDists = {}
       for target in targets:
         if target == self.pivotParameterID:
           continue
-        # print('jz is sth after preserve cdf',target)
         targetVals = trainingDict[target][0]
         nbins=max(self._minBins,int(np.sqrt(len(targetVals))))
 
@@ -1957,17 +1863,12 @@ class ARMA(supervisedLearning):
     self.preserveInputCDF = False
     if 'long Fourier signal' in settings:
       for target, peak in self.peaks.items():
-        # print('jz is a picker')
-        # print(picker)
-        # print('jz is a peaker')
-        # print(self.peaks)
         subMean = self._getMeanFromGlobal(settings, picker)
         subMean=subMean[0][target]
         th = self.peaks[target]['threshold']
         th = th - subMean
         self.peaks[target]['threshold'] = th
-        # print('jz is a updater')
-        # print(self.peaks)
+
 
   def finalizeLocalRomSegmentEvaluation(self, settings, evaluation, picker,bgId=None):
     """
@@ -2020,7 +1921,6 @@ class ARMA(supervisedLearning):
     # backtransform signal
     ## how nicely does this play with zerofiltering?
     if self.preserveInputCDF:
-      # print('jialock holmes is detecting pcdf',settings['input CDFs'])
       for target, dist in settings['input CDFs'].items():
         if len(evaluation[target])>1:
           for y in range(len(evaluation[target])):

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -469,7 +469,7 @@ class ARMA(supervisedLearning):
 
   def _evaluateScale(self, growthInfo,year):
     """
-      @ In, growthInfo, dictionary of growth value and for each target
+      @ In, growthInfo, dictionary of growth value for each target
       @ In, year, int, year index in multiyear
       @ Out, scale, float, scaling factor for each year
     """
@@ -1886,6 +1886,8 @@ class ARMA(supervisedLearning):
         ## create storage for the sampled result
         if self.multiyear:
           if bgId is not None:
+            # calculate the slice where adding back the long Fourier signal
+            # if clusterd and truncated mode
             sigLen=picker.stop-picker.start
             bgInd = bgId
             endInd = bgInd+sigLen
@@ -1893,13 +1895,16 @@ class ARMA(supervisedLearning):
               # apply growth factor
               for t, (target, growthInfo) in enumerate(self.growthFactors.items()):
                 scale =self._evaluateScale(growthInfo,y)
+                # adding Fourier with scale based on each year
                 evaluation[target][y][bgInd:endInd] += sig*scale
           else:
             for y in range(len(evaluation[target])):
               for t, (target, growthInfo) in enumerate(self.growthFactors.items()):
                 evaluation[target][y][picker] += sig*scale
         else:
+          # single year
           if bgId is not None:
+            # if cluterd and truncated mode
             sigLen=picker.stop-picker.start
             bgInd = bgId
             endInd = bgInd+sigLen

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -343,8 +343,6 @@ class ARMA(supervisedLearning):
         self._trainingCDF[target] = mathUtils.trainEmpiricalFunction(timeSeriesData, minBins=self._minBins)
       # if this target governs the zero filter, extract it now
 
-      # zeroFiltering = target == self.zeroFilterTarget
-      # if not zeroFiltering:
       if target == self.zeroFilterTarget:
         self.zeroFilterMask = self._trainZeroRemoval(timeSeriesData,tol=self.zeroFilterTol) # where zeros or less than zeros are
         self.notZeroFilterMask = np.logical_not(self.zeroFilterMask) # where data are
@@ -471,6 +469,9 @@ class ARMA(supervisedLearning):
 
   def _evaluateScale(self, growthInfo,year):
     """
+      @ In, growthInfo, dictionary of growth value and for each target
+      @ In, year, int, year index in multiyear
+      @ Out, scale, float, scaling factor for each year
     """
     growth = growthInfo['value']/100. # given in percentage
     mode = growthInfo['mode']
@@ -932,9 +933,6 @@ class ARMA(supervisedLearning):
 
     # if using zero-filter, cut the parts of the Fourier and values that correspond to the zero-value portions
     if zeroFilter:
-      # values = values[self.notZeroFilterMask]
-      # fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
-
       values = values[self.notZeroFilterMask]
       fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
       # values = values[0]
@@ -1877,6 +1875,7 @@ class ARMA(supervisedLearning):
       @ In, settings, dict, as from getGlobalRomSegmentSettings
       @ In, evaluation, dict, preliminary evaluation from the local segment ROM as {target: [values]}
       @ In, picker, slice, indexer for data range of this segment
+      @ In, bgId, int, index for the begining index for truncated mode evaluation
       @ Out, evaluation, dict, {target: np.ndarray} adjusted global evaluation
     """
     # add back in Fourier
@@ -1923,6 +1922,7 @@ class ARMA(supervisedLearning):
     if self.preserveInputCDF:
       for target, dist in settings['input CDFs'].items():
         if len(evaluation[target])>1:
+          # multiyear option
           for y in range(len(evaluation[target])):
             for t, (target, growthInfo) in enumerate(self.growthFactors.items()):
               scale =self._evaluateScale(growthInfo,y)

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -935,8 +935,6 @@ class ARMA(supervisedLearning):
     if zeroFilter:
       values = values[self.notZeroFilterMask]
       fourierSignals = fourierSignalsFull[self.notZeroFilterMask, :]
-      # values = values[0]
-      # fourierSignals = fourierSignals[0]
     else:
       fourierSignals = fourierSignalsFull
 

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -22,7 +22,6 @@ from __future__ import division, print_function, absolute_import
 import copy
 import warnings
 from collections import defaultdict, OrderedDict
-import random
 import pprint
 pp = pprint.PrettyPrinter(indent=2)
 

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -270,6 +270,8 @@ class Segments(Collection):
     for s, segment in enumerate(self._getSequentialRoms()):
       delim = self._divisionInfo['delimiters'][s]
       picker = slice(delim[0], delim[-1] + 1)
+      print('llLlLlLLlalalalala')
+      #FIXME this this line is strange
       result = segment.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker)
     result = self._templateROM.finalizeGlobalRomSegmentEvaluation(self._romGlobalAdjustments, result)
     return result
@@ -672,16 +674,26 @@ class Clusters(Segments):
       result = Segments.evaluate(self, edict)
     elif self._evaluationMode == 'truncated':
       result, weights = self._createTruncatedEvaluation(edict)
+      # print('jialock holmes is watching this edict',edict)
+
+      # print('jialock holmes is watching this results',result)
+      # print(self._clusterInfo['labels'])
+      bgId=[0]
       for r, rom in enumerate(self._roms):
         # "r" is the cluster label
         # find ROM in cluster
-        #clusterIndex = list(self._clusterInfo['map'][r]).index(rom)
+        clusterIndex = list(self._clusterInfo['map'][r]).index(rom)
+
         # find ROM in full history
-        #segmentIndex = self._getSegmentIndexFromClusterIndex(r, self._clusterInfo['labels'], clusterIndex=clusterIndex)
+        segmentIndex = self._getSegmentIndexFromClusterIndex(r, self._clusterInfo['labels'], clusterIndex=clusterIndex)
         # make local modifications based on global settings
-        delim = self._divisionInfo['delimiters'][r]
+        delim = self._divisionInfo['delimiters'][segmentIndex[0]]
         picker = slice(delim[0], delim[-1] + 1)
-        result = rom.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker)
+        # pp.pprint(self._romGlobalAdjustments)
+        # print('jialock holmes is inside clster segment rom id',r)
+        # print(bgId)
+        result = rom.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker, bgId=bgId[-1])
+        bgId.append(bgId[-1]+picker.stop-picker.start)
       # make global modifications based on global settings
       result = self._templateROM.finalizeGlobalRomSegmentEvaluation(self._romGlobalAdjustments, result, weights=weights)
     return result
@@ -818,6 +830,7 @@ class Clusters(Segments):
         result[target].append(values)
     # combine histories (we stored each one as a distinct array during collecting)
     for target, values in result.items():
+      # print('jialock holmes is watching this values',target,values)
       stackIndex = indexMap.get(target, [pivotID]).index(pivotID)
       # if target in indexMap:
       #   stackIndex = indexMap[target].index(pivotID)

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -232,7 +232,7 @@ class Segments(Collection):
       @ Out, None
     """
     Collection.setAdditionalParams(self, params)
-    for rom in self._roms:
+    for rom in self._roms + [self._templateROM]:
       rom.setAdditionalParams(params)
 
   def train(self, tdict, skipAssembly=False):
@@ -270,8 +270,6 @@ class Segments(Collection):
     for s, segment in enumerate(self._getSequentialRoms()):
       delim = self._divisionInfo['delimiters'][s]
       picker = slice(delim[0], delim[-1] + 1)
-      print('llLlLlLLlalalalala')
-      #FIXME this this line is strange
       result = segment.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker)
     result = self._templateROM.finalizeGlobalRomSegmentEvaluation(self._romGlobalAdjustments, result)
     return result
@@ -693,8 +691,12 @@ class Clusters(Segments):
         # print('jialock holmes is inside clster segment rom id',r)
         # print(bgId)
         result = rom.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker, bgId=bgId[-1])
+        # print('jialock in segment rom clolection amy',rom.multiyear,rom.growthFactors)
         bgId.append(bgId[-1]+picker.stop-picker.start)
       # make global modifications based on global settings
+      # print('jialock in segment rom clolection amy after',self._templateROM.multiyear,self._templateROM.growthFactors)
+      # print(len(result['GHI']))
+
       result = self._templateROM.finalizeGlobalRomSegmentEvaluation(self._romGlobalAdjustments, result, weights=weights)
     return result
 

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -22,7 +22,7 @@ from __future__ import division, print_function, absolute_import
 import copy
 import warnings
 from collections import defaultdict, OrderedDict
-
+import random
 import pprint
 pp = pprint.PrettyPrinter(indent=2)
 
@@ -251,8 +251,6 @@ class Segments(Collection):
     self._divisionInfo['delimiters'] = divisions[0] + divisions[1]
     # allow ROM to handle some global training
     self._romGlobalAdjustments, newTrainingDict = self._templateROM.getGlobalRomSegmentSettings(tdict, divisions)
-    # print('zj is in here')
-    # pp.pprint(self._romGlobalAdjustments)
     # train segments
     self._trainBySegments(divisions, newTrainingDict)
     self.amITrained = True
@@ -637,9 +635,7 @@ class Clusters(Segments):
     else:
       inputRequests = inputRequestsNode.value
       userRequests = self._extrapolateRequestedClusterFeatures(inputRequests)
-      # print('dasfskfhsehfglsegjlsegjlsbgljsbjlgbsjkbgjksdbgjksbgdjksgbs',userRequests)
     self._clusterFeatures = self._templateROM.checkRequestedClusterFeatures(userRequests)
-    print('debuggggg_clusterFeatures',self._clusterFeatures)
   def readAssembledObjects(self):
     """
       Collects the entities from the Assembler as needed.
@@ -672,10 +668,6 @@ class Clusters(Segments):
       result = Segments.evaluate(self, edict)
     elif self._evaluationMode == 'truncated':
       result, weights = self._createTruncatedEvaluation(edict)
-      # print('jialock holmes is watching this edict',edict)
-
-      # print('jialock holmes is watching this results',result)
-      # print(self._clusterInfo['labels'])
       bgId=[0]
       for r, rom in enumerate(self._roms):
         # "r" is the cluster label
@@ -687,15 +679,10 @@ class Clusters(Segments):
         # make local modifications based on global settings
         delim = self._divisionInfo['delimiters'][segmentIndex[0]]
         picker = slice(delim[0], delim[-1] + 1)
-        # pp.pprint(self._romGlobalAdjustments)
-        # print('jialock holmes is inside clster segment rom id',r)
-        # print(bgId)
+
         result = rom.finalizeLocalRomSegmentEvaluation(self._romGlobalAdjustments, result, picker, bgId=bgId[-1])
-        # print('jialock in segment rom clolection amy',rom.multiyear,rom.growthFactors)
         bgId.append(bgId[-1]+picker.stop-picker.start)
       # make global modifications based on global settings
-      # print('jialock in segment rom clolection amy after',self._templateROM.multiyear,self._templateROM.growthFactors)
-      # print(len(result['GHI']))
 
       result = self._templateROM.finalizeGlobalRomSegmentEvaluation(self._romGlobalAdjustments, result, weights=weights)
     return result
@@ -832,7 +819,6 @@ class Clusters(Segments):
         result[target].append(values)
     # combine histories (we stored each one as a distinct array during collecting)
     for target, values in result.items():
-      # print('jialock holmes is watching this values',target,values)
       stackIndex = indexMap.get(target, [pivotID]).index(pivotID)
       # if target in indexMap:
       #   stackIndex = indexMap[target].index(pivotID)
@@ -916,23 +902,15 @@ class Clusters(Segments):
     targets.remove(pivotID)
     clusterFeatures = defaultdict(list)
 
-    # print('zj is a debugger inside _gatherClusterFeatures ')
     for r, rom in enumerate(roms):
-      # print('rom',rom.peaks)
       # select pertinent data
       ## NOTE assuming only "leftover" roms are at the end, so the rest are sequential and match "counters"
       picker = slice(counter[r][0], counter[r][-1]+1)
       # get ROM-specific metrics
-      # print('zj is in _gatherClusterFeatures self._clusterFeatures')
-      # print(self._clusterFeatures)
       romData = rom.getLocalRomClusterFeatures(self._featureTemplate, self._romGlobalAdjustments, self._clusterFeatures, picker=picker)
 
-      # print('zj is a debugger inside _gatherClusterFeatures 2')
-      # print('r',r)
-      # pp.pprint(romData.items())
       for feature, val in romData.items():
         clusterFeatures[feature].append(val)
-      # print('end of the _gatherClusterFeatures')
     return clusterFeatures
 
   def _getSequentialRoms(self):
@@ -971,13 +949,8 @@ class Clusters(Segments):
 
   def _clusterSegments(self, roms, divisions):
     counter, remainder = divisions
-    # print('zj is inside the _clusterSegments')
-    # print(counter,remainder)
     # collect ROM features (basic stats, etc)
     clusterFeatures = self._gatherClusterFeatures(roms, counter)
-    # print('jz is a debugger in _clusterSegments')
-    # print('DEBUGG cluster features:')
-    # pp.pprint(clusterFeatures.keys())
     # future: requested metrics
     ## TODO someday
     # store clustering info, unweighted
@@ -1204,8 +1177,6 @@ class Interpolated(supervisedLearning):
         # store interpolators, by segment
         interps.append(interp)
     self.raiseADebug('Interpolator trained')
-    # print('jz is a debugger interps')
-    # pp.pprint(interps)
     # interpolate new data
     ## now we have interpolators for every segment, so for each missing segment, we
     ## need to make a new Cluster model and assign its subsequence ROMs (pre-clustering).
@@ -1221,7 +1192,6 @@ class Interpolated(supervisedLearning):
       # otherwise, create new instances
       else:
         self.raiseADebug('Interpolating year {}'.format(y))
-        # print('zj is inside _interpolateSteps')
         newModel = self._interpolateSVL(trainingDict, exampleRoms, exampleModel, self._macroTemplate, numSegments, globalInterp, interps, y)
         models.append(newModel)
         self._macroSteps[y] = newModel
@@ -1268,13 +1238,9 @@ class Interpolated(supervisedLearning):
     """ interpolates a single engine for a single macro step (e.g. a single year) """
     newModel = copy.deepcopy(exampleModel) #copy.deepcopy(template)
     segmentRoms = [] # FIXME speedup, make it a numpy array from the start
-    # print('jz is debugger level 0 in _interpolateSVL')
     for segment in range(N):
-      # print('we are now inside segment', segment)
 
       params = dict((param, interp(index)) for param, interp in segmentInterps[segment]['method'].items())
-      # print('jz is a debugger params')
-      # pp.pprint(params)
       # DEBUGG
       #fname = 'debugg_interp_y{}_s{}.pk'.format(index, segment)
       #with open(fname, 'wb') as f:
@@ -1291,14 +1257,9 @@ class Interpolated(supervisedLearning):
 
       newRom = copy.deepcopy(exampleRoms[segment])
       inputs = newRom.readFundamentalFeatures(params)
-      # print('we are the input:')
-      # pp.pprint(inputs)
       newRom.setFundamentalFeatures(inputs)
-      # print('zj is a debugger in here:')
       segmentRoms.append(newRom)
 
-    # print('we are inside _interpolateSVL after collect the segment rom')
-    # print(segmentRoms[1].getFundamentalFeatures(None))
     segmentRoms = np.asarray(segmentRoms)
     # add global params
     params = dict((param, interp(index)) for param, interp in globalInterp['method'].items())
@@ -1313,14 +1274,10 @@ class Interpolated(supervisedLearning):
     # TODO assuming histories!
     pivotID = exampleModel._templateROM.pivotParameterID
     pivotValues = trainingDict[pivotID][0] # FIXME assumes pivot is the same for each year
-    # print('DEBUGG setting global rom features:')
     params = exampleModel._roms[0].setGlobalRomFeatures(params, pivotValues)
     newModel._romGlobalAdjustments = params
-    # print('newModel',newModel)
     # finish training by clustering
-    # print('zj is debugger inside _interpolateSVL')
     newModel._clusterSegments(segmentRoms, exampleModel.divisions)
-    # print('zj is after newModel._clusterSegments')
     newModel.amITrained = True # template.amITrained
     return newModel
 
@@ -1462,7 +1419,6 @@ def _plotSignalsClustered(labels, clusterFeatures, slices, trainingSet):
   for target in trainingSet:
     if target in ['Time', 'scaling']:
       continue
-    # print('')
     print('DEBUGG plotting target "{}"'.format(target))
     fig, ax = plt.subplots(figsize=(12, 10))
     ymin = trainingSet[target][0].min()

--- a/tests/framework/ROM/TimeSeries/ARMA/Peaks/dataSet.csv
+++ b/tests/framework/ROM/TimeSeries/ARMA/Peaks/dataSet.csv
@@ -1,2 +1,2 @@
 scaling,filename
-1,hrl.csv
+1,dataSet_0.csv


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

When Long term Fourier assigned zero-filter might over detrending the data.
Picker of adding the Fourier back is wrong   
Preserve CDF of limited training data need to be scaled

##### What are the significant changes in functionality due to this change request?

Zero filter mask now means the data that are all zero.

Change the double mask of interpolateDist method in ARMA into a tuple mask to remove the 
future warning:
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`

Add the evaluate scale in multiyear
----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

