### PR TITLE
Segmenting-DMD

### DIFF
--- a/framework/Models/ROM.py
+++ b/framework/Models/ROM.py
@@ -67,7 +67,7 @@ class ROM(Dummy):
     segment.addParam('grouping', segmentGroups)
     subspace = InputData.parameterInputFactory('subspace', contentType=InputData.StringType)
     subspace.addParam('divisions', InputData.IntegerType, False)
-    subspace.addParam('pivotLength', InputData.FloatType, False)
+    subspace.addParam('pivotLength', InputData.FloatListType, False)
     subspace.addParam('shift', InputData.StringType, False)
     segment.addSub(subspace)
     clusterEvalModeEnum = InputData.makeEnumType('clusterEvalModeEnum', 'clusterEvalModeType', ['clustered', 'truncated', 'full'])
@@ -265,6 +265,7 @@ class ROM(Dummy):
     inputSpecification.addSub(InputData.parameterInputFactory("coeffRegressor", contentType=coeffRegressorEnumType))
     # DMD
     inputSpecification.addSub(InputData.parameterInputFactory("rankSVD", contentType=InputData.IntegerType))
+    #inputSpecification.addSub(InputData.parameterInputFactory("rankSVD", contentType=InputData.IntegerTupleType))# List of integers
     inputSpecification.addSub(InputData.parameterInputFactory("energyRankSVD", contentType=InputData.FloatType))
     inputSpecification.addSub(InputData.parameterInputFactory("rankTLSQ", contentType=InputData.IntegerType))
     inputSpecification.addSub(InputData.parameterInputFactory("exactModes", contentType=InputData.BoolType))

--- a/framework/SupervisedLearning/DynamicModeDecomposition.py
+++ b/framework/SupervisedLearning/DynamicModeDecomposition.py
@@ -89,6 +89,8 @@ class DynamicModeDecomposition(supervisedLearning):
       @ Out, None
     """
     self.__dict__.update(state)
+    # Although next line should not be executed unless the ROM is trained, this is allowed through ROM collections which is the only exception so far.
+    # That's why the if statement was added. 
     if self.amITrained:
       self.KDTreeFinder = spatial.KDTree(self.featureVals)
 

--- a/framework/SupervisedLearning/DynamicModeDecomposition.py
+++ b/framework/SupervisedLearning/DynamicModeDecomposition.py
@@ -89,7 +89,8 @@ class DynamicModeDecomposition(supervisedLearning):
       @ Out, None
     """
     self.__dict__.update(state)
-    self.KDTreeFinder = spatial.KDTree(self.featureVals)
+    if self.amITrained:
+      self.KDTreeFinder = spatial.KDTree(self.featureVals)
 
   def _localNormalizeData(self,values,names,feat):
     """
@@ -320,4 +321,13 @@ class DynamicModeDecomposition(supervisedLearning):
       @ Out, self.dmdParams, dict, the dict of the SM settings
     """
     return self.dmdParams
-
+  
+  def adjustLocalRomSegment(self, settings, picker):
+    """
+      Adjusts this ROM to account for it being a segment as a part of a larger ROM collection.
+      Call this before training the subspace segment ROMs
+      Note this is called on the LOCAL subsegment ROMs, NOT on the GLOBAL templateROM from the ROMcollection!
+      @ In, settings, object, arbitrary information about ROM clustering settings from getGlobalRomSegmentSettings
+      @ Out, None
+    """
+    pass # override as needed

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -420,25 +420,30 @@ class Segments(Collection):
       pivot = trainingSet[subspace][0]
       dataLen = len(pivot) # TODO assumes syncronized histories, or single history
       self._divisionInfo['historyLength'] = dataLen # TODO assumes single pivotParameter
-      if mode == 'split':
+      if mode == 'split': # If the user inputs number of divisions
         numSegments = value # renamed for clarity
         # divide the subspace into equally-sized segments, store the indexes for each segment
         counter = np.array_split(np.arange(dataLen), numSegments)
         # only store bounds, not all indices in between -> note that this is INCLUSIVE!
         counter = list((c[0], c[-1]) for c in counter)
         # Note that "segmented" doesn't have "unclustered" since chunks are evenly sized
-      elif mode == 'value':
+      elif mode == 'value': # If the user inputs the pivotlength(s)
+        # Length of each segment is given, i.e., pivotLength is a list
         if len(value)>1:
           numSegments = len(value) # numSegments is length of the pivotLength list
           floor = 0
           counter = []
+          # search for the indecies of the given pivotLength
           cross = np.searchsorted(trainingSet[subspace][0], value)
           for i in cross:
+            # if the given index is at the end of the pivot parameter:
             if i == dataLen-1:
               counter.append((floor-1,i))
               break
+            # otherwise
             counter.append((floor,i-1))
             floor = i
+        # segments are determined by a single pivotLength, i.e., pivotLength is a float not a list of floats
         else:
           segmentValue = value[0] # renamed for clarity
           # divide the subspace into segments with roughly the same pivot length (e.g. time length)

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -192,7 +192,11 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
       targetValues = np.concatenate([np.asarray(arr)[sl] for arr in targetValues], axis=np.asarray(targetValues[0]).ndim)
 
     # construct the evaluation matrixes
-    featureValues = np.zeros(shape=(np.shape(targetValues)[0],len(self.features)))
+    
+    # targetValues shouls be #Samples x #TimeStepsWithinSegment x #Targets
+    ## TODO: We need dimensionality assert statements all over the code especially for the segmenting/clustering Rom bussiness.
+     
+    featureValues = np.zeros(shape=(np.shape(targetValues)[0],len(self.features))) # now featureValues is #Samples x #Features   
     for cnt, feat in enumerate(self.features):
       if feat not in names:
         self.raiseAnError(IOError,'The feature sought '+feat+' is not in the training set')
@@ -201,7 +205,9 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
         resp = self.checkArrayConsistency(valueToUse, self.isDynamic())
         if not resp[0]:
           self.raiseAnError(IOError,'In training set for feature '+feat+':'+resp[1])
-        valueToUse = np.asarray(valueToUse)
+        valueToUse = np.asarray(valueToUse) # valueToUse is #Samples x #TimeStepsWithinSegment
+        # if the first dimension in valuesToUse is != first dimension in featureValues (#Samples),
+        # yet I prefer to use np.shape(featureValues[0]) instead!  
         if np.shape(valueToUse)[0] != featureValues[:,0].size:
           self.raiseAWarning('feature values:',featureValues[:,0].size,tag='ERROR')
           self.raiseAWarning('target values:',len(valueToUse),tag='ERROR')

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -81,8 +81,6 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
     else:
       if type(arrayIn).__name__ not in ['ndarray','c1darray']:
         return (False,' The object is not a numpy array. Got type: '+type(arrayIn).__name__)
-      if len(np.asarray(arrayIn).shape) > 1:
-        return(False, ' The array must be 1-d. Got shape: '+str(np.asarray(arrayIn).shape))
     return (True,'')
 
   def __init__(self,messageHandler,**kwargs):
@@ -194,7 +192,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
       targetValues = np.concatenate([np.asarray(arr)[sl] for arr in targetValues], axis=np.asarray(targetValues[0]).ndim)
 
     # construct the evaluation matrixes
-    featureValues = np.zeros(shape=(len(targetValues),len(self.features)))
+    featureValues = np.zeros(shape=(np.shape(targetValues)[0],len(self.features)))
     for cnt, feat in enumerate(self.features):
       if feat not in names:
         self.raiseAnError(IOError,'The feature sought '+feat+' is not in the training set')
@@ -204,7 +202,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
         if not resp[0]:
           self.raiseAnError(IOError,'In training set for feature '+feat+':'+resp[1])
         valueToUse = np.asarray(valueToUse)
-        if len(valueToUse) != featureValues[:,0].size:
+        if np.shape(valueToUse)[0] != featureValues[:,0].size:
           self.raiseAWarning('feature values:',featureValues[:,0].size,tag='ERROR')
           self.raiseAWarning('target values:',len(valueToUse),tag='ERROR')
           self.raiseAnError(IOError,'In training set, the number of values provided for feature '+feat+' are != number of target outcomes!')
@@ -337,7 +335,18 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta),MessageHandler.Mess
       @ Out, None
     """
     writeTo.addScalar('ROM',"noInfo",'ROM has no special output options.')
-
+  
+  def writeGlobalXML(self, writeTo, targets=None, skip=None):
+    """
+      Writs out Global Segment information.
+      Overload in subclasses.
+      @ In, writeTo, xmlUtils.StaticXmlElement, StaticXmlElement to write to
+      @ In, targets, list, optional, list of targets for whom information should be written, unused
+      @ In, skip, list, optional, list of targets to skip, unused
+      @ Out, None
+    """
+    pass # override as needed
+  
   def isDynamic(self):
     """
       This method is a utility function that tells if the relative ROM is able to


### PR DESCRIPTION
Making time segmentation work for DMD.

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Rime segmentation only worked for ARMA, this is an attempt to generalize it to other time-dependent surrogate models.

##### What are the significant changes in functionality due to this change request?
User build a sequence of DMD surrogates based on a user-selection of number of divisions or length(s) of divisions.
##### TODO:
1. allow user to input different DMD specs for each segment, such as different ranks, modes, and/or optimized modes selection.
2. It will be great of the algorithm is extended to be smart enough to determine the time windows to fit the best number of segments and size of segments which can be learned from temporal bahavious as a function of the sampled input parameters.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

